### PR TITLE
MCPサーバーのuuid生成する実装

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,94 @@
-// index.ts
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+} from '@modelcontextprotocol/sdk/types.js';
+import { v4 as uuidv4 } from 'uuid';
+
+class UuidGeneratorServer {
+  private server: Server;
+
+  constructor() {
+    this.server = new Server(
+      {
+        name: 'uuid-generator',
+        version: '0.1.0',
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      }
+    );
+
+    this.setupToolHandlers();
+    
+    // エラーハンドリング
+    this.server.onerror = (error) => console.error('[MCP Error]', error);
+    process.on('SIGINT', async () => {
+      await this.server.close();
+      process.exit(0);
+    });
+  }
+
+  private setupToolHandlers() {
+    // ツール一覧の設定
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: [
+        {
+          name: 'generate_uuid',
+          description: 'Generate a random UUID v4',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+          },
+        },
+      ],
+    }));
+
+    // ツールの実装
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      if (request.params.name !== 'generate_uuid') {
+        throw new McpError(
+          ErrorCode.MethodNotFound,
+          `Unknown tool: ${request.params.name}`
+        );
+      }
+
+      try {
+        const uuid = uuidv4();
+        return {
+          content: [
+            {
+              type: 'text',
+              text: uuid,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to generate UUID: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    });
+  }
+
+  async run() {
+    const transport = new StdioServerTransport();
+    await this.server.connect(transport);
+    console.error('UUID Generator MCP server running on stdio');
+  }
+}
+
+const server = new UuidGeneratorServer();
+server.run().catch(console.error);


### PR DESCRIPTION
# 概要
MCPサーバーのuuidを生成する実装をしました。

## MCP Client設定方法
VSCode用の設定ファイルを以下の場所に作成してください：

- path
  - macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
  - Windows: `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json`

- 設定用のjsonファイル
```json
{
  "mcpServers": {
    "uuid-generator": {
      "command": "node",
      "args": ["PATH_TO_REPO/dist/index.js"],
      "env": {},
      "disabled": false,
      "autoApprove": []
    }
  }
}
```
※ PATH_TO_REPOは、クローンしたリポジトリの絶対パスに置き換えてください。

- 設定後、vscodeを再起動する

## 動作確認

Clineで以下のコマンドを実行して動作確認:
`use_mcp_tool uuid-generator generate_uuid` actモードで実行してください。

- [x] uuidが生成されることを確認
<img width="544" alt="image" src="https://github.com/user-attachments/assets/9d084930-9e4a-45de-aed0-09dd1666d57d" />
